### PR TITLE
NEW Pass through the Content-type when using .php extension

### DIFF
--- a/code/CachedPHPPage.tmpl
+++ b/code/CachedPHPPage.tmpl
@@ -9,6 +9,7 @@
 
 define('MAX_AGE', '**MAX_AGE**');
 define('LAST_MODIFIED', '**LAST_MODIFIED**');
+define('CONTENT_TYPE', '**CONTENT_TYPE**');
 
 if(MAX_AGE > 0) {
 	header("Cache-Control: max-age=" . MAX_AGE);
@@ -19,6 +20,7 @@ if(MAX_AGE > 0) {
 
 header("Expires: " . gmdate('D, d M Y H:i:s', time() + MAX_AGE) . ' GMT');
 header("Last-modified: " . gmdate('D, d M Y H:i:s', strtotime(LAST_MODIFIED)) . ' GMT');
+header('Content-Type: '.CONTENT_TYPE);
 
 if(isset($_SERVER['HTTP_IF_MODIFIED_SINCE'])) {
 	if(strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) >= strtotime(LAST_MODIFIED)) {

--- a/code/extensions/FilesystemPublisher.php
+++ b/code/extensions/FilesystemPublisher.php
@@ -248,10 +248,10 @@ class FilesystemPublisher extends StaticPublisher {
 					if($response->getStatusCode() == '301' || $response->getStatusCode() == '302') {
 						$content = $this->generatePHPCacheRedirection($response->getHeader('Location'));
 					} else {
-						$content = $this->generatePHPCacheFile($response->getBody(), HTTP::get_cache_age(), date('Y-m-d H:i:s'));
+						$content = $this->generatePHPCacheFile($response->getBody(), HTTP::get_cache_age(), date('Y-m-d H:i:s'), $response->getHeader('Content-Type'));
 					}
 				} else {
-					$content = $this->generatePHPCacheFile($response . '', HTTP::get_cache_age(), date('Y-m-d H:i:s'));
+					$content = $this->generatePHPCacheFile($response . '', HTTP::get_cache_age(), date('Y-m-d H:i:s'), $response->getHeader('Content-Type'));
 				}
 				
 			// HTML file caching generally just creates a simple file
@@ -345,15 +345,15 @@ class FilesystemPublisher extends StaticPublisher {
 	 * @param string $content
 	 * @param string $age
 	 * @param string $lastModified
+	 * @param string $contentType
 	 *
 	 * @return string
 	 */
-	protected function generatePHPCacheFile($content, $age, $lastModified) {
+	protected function generatePHPCacheFile($content, $age, $lastModified, $contentType) {
 		$template = file_get_contents(STATIC_MODULE_DIR . '/code/CachedPHPPage.tmpl');
-
 		return str_replace(
-			array('**MAX_AGE**', '**LAST_MODIFIED**', '**CONTENT**'),
-			array((int)$age, $lastModified, $content),
+			array('**MAX_AGE**', '**LAST_MODIFIED**', '**CONTENT**', '**CONTENT_TYPE**'),
+			array((int)$age, $lastModified, $content, $contentType),
 			$template
 		);
 	}

--- a/tests/FilesystemPublisherTest.php
+++ b/tests/FilesystemPublisherTest.php
@@ -182,7 +182,29 @@ class FilesystemPublisherTest extends SapphireTest {
 
 		$response = Director::test($l2_2->AbsoluteLink()); 
 		$this->assertEquals(trim($response->getBody()), "linkcurrent", "current page is level 2-2"); 
-	} 
+	}
+
+	public function testContentTypeHTML() {
+		SiteTree::remove_extension('FilesystemPublisher');
+		SiteTree::add_extension("FilesystemPublisher('assets/FilesystemPublisherTest-static-folder/', 'php')");
+		$l1 = new StaticPublisherTestPage();
+		$l1->URLSegment = 'mimetype';
+ 		$l1->write();
+		$l1->doPublish();
+		$response = Director::test('mimetype');
+		$this->assertEquals($response->getHeader('Content-Type'), 'text/html; charset=utf-8', 'Content-Type should be text/html; charset=utf-8');
+	}
+
+	public function testContentTypeJSON() {
+		SiteTree::remove_extension('FilesystemPublisher');
+		SiteTree::add_extension("FilesystemPublisher('assets/FilesystemPublisherTest-static-folder/', 'php')");
+		$l1 = new StaticPublisherTestPage();
+		$l1->URLSegment = 'mimetype';
+ 		$l1->write();
+		$l1->doPublish();
+		$response = Director::test('mimetype/json');
+		$this->assertEquals($response->getHeader('Content-Type'), 'application/json', 'Content-Type should be application/json');
+	}
 }
 
 /**
@@ -207,6 +229,14 @@ class StaticPublisherTestPage extends Page implements TestOnly {
 /**
  * @package staticpublisher
  */
-class StaticPublisherTestPage_Controller extends Page_Controller { 
+class StaticPublisherTestPage_Controller extends Page_Controller {
+
+	public function json(SS_HTTPRequest $request) {
+
+		$response = new SS_HTTPResponse('{"firstName": "John"}');
+		$response->addHeader('Content-Type', 'application/json');
+		return $response;
+
+	}
 
 }


### PR DESCRIPTION
This patch should set the correct content-type header depending on the source and using the .php type of filesystem publishing.

See issue #19 for reference.
