### PR TITLE
FIX Removing dependence on cache dir name

### DIFF
--- a/code/tasks/RebuildStaticCacheTask.php
+++ b/code/tasks/RebuildStaticCacheTask.php
@@ -114,7 +114,7 @@ class RebuildStaticCacheTask extends BuildTask
 
             if (Config::inst()->get('FilesystemPublisher', 'domain_based_caching')) {
                 // Glob each dir, then glob each one of those
-                foreach (glob(BASE_PATH . '/cache/*', GLOB_ONLYDIR) as $cacheDir) {
+                foreach (glob($cacheBaseDir .'/*', GLOB_ONLYDIR) as $cacheDir) {
                     foreach (glob($cacheDir.'/*') as $cacheFile) {
                         $searchCacheFile = trim(str_replace($cacheBaseDir, '', $cacheFile), '\/');
                         


### PR DESCRIPTION
Removing the dependence that cache dir is actually named `cache`