### PR TITLE
Only publish 'legal' pages

### DIFF
--- a/code/extensions/StaticPublisher.php
+++ b/code/extensions/StaticPublisher.php
@@ -149,6 +149,9 @@ abstract class StaticPublisher extends DataExtension {
 		}
 
 		$urls = array_unique($urls);
+		
+		$legalPages = singleton('Page')->allPagesToCache();
+		$urls = array_intersect($urls, $legalPages);
 
 		$this->publishPages($urls);
 	}


### PR DESCRIPTION
The `republish` function now only publishes pages that are returned in the `allPagesToCache` function in `Page`