### PR TITLE
Remove random publishing of 10 pages

### DIFF
--- a/code/extensions/StaticPublisher.php
+++ b/code/extensions/StaticPublisher.php
@@ -134,13 +134,6 @@ abstract class StaticPublisher extends DataExtension
         
         if ($this->owner->hasMethod('pagesAffectedByChanges')) {
             $urls = $this->owner->pagesAffectedByChanges($original);
-        } else {
-            $pages = Versioned::get_by_stage('SiteTree', 'Live', '', '', '', 10);
-            if ($pages) {
-                foreach ($pages as $page) {
-                    $urls[] = $page->AbsoluteLink();
-                }
-            }
         }
         
         // Note: Similiar to RebuildStaticCacheTask->rebuildCache()


### PR DESCRIPTION
At the moment we seem to publish 10 pages (seemingly at random) if we aren't told about `pagesAffectedByChanges`, this seems arbitrary and unnecessary. It'll add delay to publishing and cause needless caching of most likely the same 10 pages every time.