### PR TITLE
Fixing composer deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
 		"email": "sam@silverstripe.com"
 	}],
 	"require": {
-		"silverstripe/framework": "~3.1"
+		"silverstripe/cms": "~3.1"
 	}
 }


### PR DESCRIPTION
This module is tightly coupled to CMS features rather than Framework alone.

eg:

`onAfterPublish`, `onAfterUnpublish`, `Versioned::get_from_stage('SiteTree', ...)`, `singleton('Page')` are all CMS deps.